### PR TITLE
Add a setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ These add-ons add syntax highlighting for GraphQL query document files to Xcode.
 
 - Copy `GraphQL.ideplugin` to `~/Library/Developer/Xcode/Plug-ins`
 - Copy `GraphQL.xclangspec` to `~/Library/Developer/Xcode/Specifications`
+
+Or simply run `./setup.sh`

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+mkdir  ~/Library/Developer/Xcode/Specifications
+cp -r GraphQL.ideplugin ~/Library/Developer/Xcode/Plug-ins/
+cp GraphQL.xclangspec ~/Library/Developer/Xcode/Specifications


### PR DESCRIPTION
This adds a tiny script installing the plugin, easier than copy/pasting the two paths from the readme or browsing `Finder`