### PR TITLE
Attempt to add Apollo compiler plugin

### DIFF
--- a/Apollo.xcplugin/Contents/Info.plist
+++ b/Apollo.xcplugin/Contents/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.intel.notreally.apollographql.xcode.apollo</string>
+	<key>CFBundleName</key>
+	<string>Apollo Xcode Plug-in</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>8A66E736-A720-4B3C-92F1-33D9962C69DF</string>
+		<string>65C57D32-1E9B-44B8-8C04-A27BA7AAE2C4</string>
+		<string>DA4FDFD8-C509-4D8B-8B55-84A7B66AE701</string>
+		<string>E0A62D1F-3C18-4D74-BFE5-A4167D643966</string>
+		<string>DFFB3951-EB0A-4C09-9DAC-5F2D28CC839C</string>
+		<string>CA351AD8-3176-41CB-875C-42A05C7CDEC7</string>
+		<string>DF11C142-1584-4A99-87AC-1925D5F5652A</string>
+		<string>89CB8A86-8683-4928-AF66-11A6CE26A829</string>
+	</array>
+	<key>XCPluginHasUI</key>
+	<false/>
+</dict>
+</plist>

--- a/Apollo.xcplugin/Contents/Resources/Apollo.xcspec
+++ b/Apollo.xcplugin/Contents/Resources/Apollo.xcspec
@@ -1,0 +1,66 @@
+(
+	{
+		Type = FileType;
+		Identifier = "sourcecode.graphql";
+		BasedOn = sourcecode;
+		Name = "GraphQL source files";
+		Extensions = (
+			graphql,
+		);
+		ComputerLanguage = graphql;
+		Language = "xcode.lang.graphql";
+		AppliesToBuildRules = YES;
+		UTI = "public.graphql-source";
+	},
+	{
+		Type = Compiler;
+		Identifier = "com.apollographql.codegen";
+		Name = "Apollo GraphQL Codegen";
+		Description = "Generates Swift files from GraphQL schema and query documents.";
+		CommandLine = "apollo-codegen generate [inputs] --output [output] [options]";
+		RuleName = "ApolloCodegen [inputs] [output]";
+		InputFileTypes = (
+			"sourcecode.graphql",
+		);
+		OutputPath = "${DerivedFilesDir}/ApolloGenerated";
+		InputFileGroupings = (
+			tool,
+		);
+		Outputs = (
+			// How do you specify a list of input files here?
+			"${OutputPath}/${InputFileBase}.graphql.swift",
+			"${OutputPath}/Types.graphql.swift",
+		);
+		ExecDescription = "Generate Swift source files for GraphQL query documents";
+		ProgressDescription = "Generating Swift source files for GraphQL query documents";
+		IsArchitectureNeutral = YES;
+		SynthesizeBuildRule = YES;
+		CommandOutputParser = (
+			("()()^warning: (.*)",  emit-warning),
+			("()()^error: (.*)",  emit-error),
+			(
+				"^([^:]*):([^:]*): warning: (.*)$",
+				"emit-warning",
+			),
+			(
+				"^([^:]*):([^:]*): error: (.*)$",
+				"emit-error",
+			),
+		);
+		EnvironmentVariables = {
+			CONFIGURATION = "$(CONFIGURATION)";
+			XCODE_VERSION_ACTUAL = "${XCODE_VERSION_ACTUAL}";
+			FRAMEWORK_SEARCH_PATHS = "$(FRAMEWORK_SEARCH_PATHS)";
+		};
+		Options = (
+      {
+					Name = "GRAPHQL_SCHEMA_FILE";
+					DisplayName = "GraphQL Schema File";
+          Type = Path;
+					DefaultValue = "${SRCROOT}/${TARGET_NAME}/schema.json";
+          CommandLineFlag = "--schema";
+          IsInputDependency = Yes;
+      },
+		);
+  }
+)

--- a/Apollo.xcplugin/Contents/Resources/apollo-codegen
+++ b/Apollo.xcplugin/Contents/Resources/apollo-codegen
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+APOLLO_FRAMEWORK_PATH=$(eval find $FRAMEWORK_SEARCH_PATHS -name "Apollo.framework" -maxdepth 1)
+
+if [ -z "$APOLLO_FRAMEWORK_PATH" ]; then
+echo "error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project."
+exit 1
+fi
+
+exec $APOLLO_FRAMEWORK_PATH/check-and-run-apollo-codegen.sh "$@"


### PR DESCRIPTION
This is a (probably failed) attempt to add an Apollo compiler plugin. With some reverse engineering, it turns out copying `Apollo.xcplugin` to `/Library/Application Support/Developer/9.0/Xcode/Plug-ins/` allows us to add an automatic build rule to invoke `apollo-codegen` and add outputs. 

In contrast to the custom build tools configurable through the Xcode UI, this allows us to set `InputFileGroupings`, meaning we get a list of input files instead of being invoked once per file. That makes a lot more sense for `apollo-codegen` because we need to process all `.graphql` files together to resolve fragments, and we also need to generate a single `Types.graphql.swift` with types encountered in all files.

I almost got this working, but there doesn't seem to be a way to specify multiple outputs that depend on the list of inputs. In addition, this doesn't seem to work with the (currently experimental) new build system. Still leaving it here to preserve the effort, but we probably need to look for other solutions.