### PR TITLE
Add Xcode 10 uuid

### DIFF
--- a/GraphQL.ideplugin/Contents/Info.plist
+++ b/GraphQL.ideplugin/Contents/Info.plist
@@ -35,7 +35,8 @@
 		<string>C3998872-68CC-42C2-847C-B44D96AB2691</string>
 		<string>B395D63E-9166-4CD6-9287-6889D507AD6A</string>
 		<string>EE23884D-A5C0-4163-94CF-DBBF3A5ED8D6</string>
-		<string>426A087B-D3AA-431A-AFDF-F135EC00DE1C</string>        
+		<string>426A087B-D3AA-431A-AFDF-F135EC00DE1C</string>
+		<string>8B9F56A7-4D8B-41AA-A65D-D4906CDF1539</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>


### PR DESCRIPTION
Adds the appropriate `DVTPluginCompatibilityUUID` to the plugin's `info.plist`.