### PR TITLE
Add a success message after installation completes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -15,3 +15,5 @@ fi
 
 cp -r GraphQL.ideplugin $plugins_dir
 cp GraphQL.xclangspec $spec_dir
+
+echo '🎉 Apollo Xcode Add-ons installation has completed! Please close and re-open Xcode.'


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

I ran the `setup.sh` script multiple times without realizing it silently succeeded. In my opinion, a console message after a successful installation would be beneficial and provide clarity to developers using this (awesome) Xcode plugin.