### PR TITLE
Update setup script to put stuff directly into Xcode's path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 These add-ons add syntax highlighting for GraphQL query document files to Xcode.
 
+## Wait, aren't Xcode plugins dead?
+
+Since Apple started code-signing Xcode with Xcode 9, Xcode plugins are indeed [mostly dead](https://www.imdb.com/title/tt0093779/characters/nm0000345). 
+
+However, there are a few small, limited purposes for which they still work, including recognizing particular file types as tied to particular languages, which is what this plugin allows Xcode to do.
+
 ## Installation
+
+**NOTE**: This requires some mucking around with files provided directly by Xcode due to some [changes to undocumented APIs for adding syntax highlighting in Xcode 11](https://github.com/apollographql/xcode-graphql/issues/23). Apple friends, please see FB7321565 for further details. 
+
+This all works as Xcode of 11.3, but be aware that it's a bit more fragile than we'd like it to be. Please file an issue on this repo if it stops working in a new version and we'll investigate. 
 
 ### Setup script
 
@@ -13,6 +23,9 @@ sudo ./setup.sh
 ```
 
 Particularly if you are running Catalina, you will need to use `sudo` in order to make this work due to changes in the permissions model.
+
+Once the setup script has finished, restart Xcode and click the "Load bundle" button on the permissions dialog that appears in Xcode when it restarts. 
+
 ### Manual installation
 
 Due to the aforementioned changes in APIs, manual installation works slightly differently for Xcode 11 and up vs. 10 and lower. 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,39 @@ These add-ons add syntax highlighting for GraphQL query document files to Xcode.
 
 ### Setup script
 
-Run the following command in your terminal:
+If you're running Xcode 11 or higher, the fastest way to install is to `cd` into the directory where this repo has been checked out or downloaded, and run the following command in your terminal:
 
 ```
-./setup.sh
+sudo ./setup.sh
 ```
 
+Particularly if you are running Catalina, you will need to use `sudo` in order to make this work due to changes in the permissions model.
 ### Manual installation
+
+Due to the aforementioned changes in APIs, manual installation works slightly differently for Xcode 11 and up vs. 10 and lower. 
+
+**Note**: On Catalina you may need to `sudo` to get these commands to work. 
+
+### Xcode 11 and Higher
+
+- Copy the `GraphQL.ideplugin` directory to `~/Library/Developer/Xcode/Plug-ins/`:
+
+	```
+	cp -r GraphQL.ideplugin ~/Library/Developer/Xcode/Plug-ins/
+	```
+- Copy the `GraphQL.xclangspec` file to `/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications`:
+
+	```
+	cp GraphQL.xclangspec /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications
+	```
+
+- Copy the `Xcode.SourceCodeLanguage.GraphQL.plist` file to `/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata`:
+
+```
+cp Xcode.SourceCodeLanguage.GraphQL.plist /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata
+```
+
+### Versions of Xcode prior to 11
 
 Please note that if you are running Xcode 8 the `Plug-ins` and `Specifications` directories might not exist.
 

--- a/Xcode.SourceCodeLanguage.GraphQL.plist
+++ b/Xcode.SourceCodeLanguage.GraphQL.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>commentSyntaxes</key>
+	<array>
+		<dict>
+			<key>prefix</key>
+			<string>/*</string>
+			<key>suffix</key>
+			<string>*/</string>
+		</dict>
+		<dict>
+			<key>prefix</key>
+			<string>//</string>
+		</dict>
+	</array>
+	<key>conformsToLanguageIdentifiers</key>
+	<array>
+		<string>Xcode.SourceCodeLanguage.Generic</string>
+	</array>
+	<key>fileDataTypeIdentifiers</key>
+	<array>
+		<string>com.netscape.javascript-source</string>
+	</array>
+	<key>identifier</key>
+	<string>Xcode.SourceCodeLanguage.GraphQL</string>
+	<key>isHidden</key>
+	<false/>
+	<key>languageName</key>
+	<string>GraphQL</string>
+	<key>languageSpecification</key>
+	<string>xcode.lang.graphql</string>
+	<key>supportsIndentation</key>
+	<true/>
+	<key>allowWhitespaceTrimming</key>
+	<true/>
+	<key>requiresHardTabs</key>
+	<false/>
+	<key>indentationTriggers</key>
+	<array>
+		<string>{</string>
+		<string>}</string>
+	</array>
+</dict>
+</plist>

--- a/setup.sh
+++ b/setup.sh
@@ -2,20 +2,32 @@
 
 set -o xtrace
 
-plugins_dir=~/Library/Developer/Xcode/Plug-ins/
-spec_dir=~/Library/Developer/Xcode/Specifications
 
-# Create Plug-ins directory if it doesn't exist
+# Create plug-ins directory if it doesn't exist
+plugins_dir=~/Library/Developer/Xcode/Plug-ins/
 if [ ! -d "$plugins_dir" ]; then
 	mkdir $plugins_dir
 fi
 
+# Copy the IDE Plugin to the plug-ins directory
+cp -r GraphQL.ideplugin $plugins_dir
+
 # Create Specifications directory if it doesn't exist
+spec_dir=/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications
 if [ ! -d "$spec_dir" ]; then
 	mkdir $spec_dir
 fi
 
-cp -r GraphQL.ideplugin $plugins_dir
+# Copy the language specification to the specs directory
 cp GraphQL.xclangspec $spec_dir
 
-echo '🎉 Apollo Xcode Add-ons installation has completed! Please close and re-open Xcode.'
+# Create the language metadata directory if it doesn't exist
+metadata_dir=/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata
+if [ ! -d "$metadata_dir" ]; then
+	mkdir $metadata_dir
+fi
+
+# Copy the source code language plist to the metadata directory
+cp Xcode.SourceCodeLanguage.GraphQL.plist $metadata_dir
+
+echo '🎉 Apollo Xcode Add-ons installation has completed! Please restart Xcode and click "Load bundle" when an alert shows about GraphQL.ideplugin.'


### PR DESCRIPTION
Please see #23 for a ton of discussion around this. 

It's become abundantly clear that Apple's not going to fix this anytime soon, so I'm throwing in the towel and having the script move things into Xcode's path where they need to be in order for syntax highlighting to work in Xcode 11. 

I've also updated the `README` to make it clear that this is not as stable as we'd like it to be, because having to put stuff in Xcode's path (and especially needing to `sudo` it in Catalina) makes me feel like I need a shower. 

But hey, it works. 