### PR TITLE
Updated the setup script to get Xcode's path from xcode-select.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,7 @@
 
 set -o xtrace
 
+xcode_contents_dir=$(dirname "$(xcode-select -p)")
 
 # Create plug-ins directory if it doesn't exist
 plugins_dir=~/Library/Developer/Xcode/Plug-ins/
@@ -13,7 +14,7 @@ fi
 cp -r GraphQL.ideplugin $plugins_dir
 
 # Create Specifications directory if it doesn't exist
-spec_dir=/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications
+spec_dir="${xcode_contents_dir}/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications"
 if [ ! -d "$spec_dir" ]; then
 	mkdir $spec_dir
 fi
@@ -22,7 +23,7 @@ fi
 cp GraphQL.xclangspec $spec_dir
 
 # Create the language metadata directory if it doesn't exist
-metadata_dir=/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata
+metadata_dir="${xcode_contents_dir}/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata"
 if [ ! -d "$metadata_dir" ]; then
 	mkdir $metadata_dir
 fi


### PR DESCRIPTION
This allows users that have Xcode installed somewhere other than '/Application/Xcode.app' to run the setup script without having to manually edit the script with their Xcode path.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->