### PR TITLE
Update Installation instructions + add a simpler setup script for non-11 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,31 +8,58 @@ Since Apple started code-signing Xcode with Xcode 9, Xcode plugins are indeed [m
 
 However, there are a few small, limited purposes for which they still work, including recognizing particular file types as tied to particular languages, which is what this plugin allows Xcode to do.
 
-## Installation
+## Installation via script
 
-**NOTE**: This requires some mucking around with files provided directly by Xcode due to some [changes to undocumented APIs for adding syntax highlighting in Xcode 11](https://github.com/apollographql/xcode-graphql/issues/23). Apple friends, please see FB7321565 for further details. 
-
-This all works as Xcode of 11.3, but be aware that it's a bit more fragile than we'd like it to be. Please file an issue on this repo if it stops working in a new version and we'll investigate. 
-
-### Setup script
-
-If you're running Xcode 11 or higher, the fastest way to install is to `cd` into the directory where this repo has been checked out or downloaded, and run the following command in your terminal:
-
-```
-sudo ./setup.sh
-```
-
-Particularly if you are running Catalina, you will need to use `sudo` in order to make this work due to changes in the permissions model.
+The fastest way to install is to `cd` into the directory where this repo has been checked out or downloaded, and run one of the included install scripts.
 
 Once the setup script has finished, restart Xcode and click the "Load bundle" button on the permissions dialog that appears in Xcode when it restarts. 
 
-### Manual installation
+### Anything other than Xcode 11
 
-Due to the aforementioned changes in APIs, manual installation works slightly differently for Xcode 11 and up vs. 10 and lower. 
+The script to run for versions of Xcode other than 11.x is `setup.sh`: 
 
-**Note**: On Catalina you may need to `sudo` to get these commands to work. 
+```
+./setup.sh
+```
 
-### Xcode 11 and Higher
+### Xcode 11
+
+> **NOTE**: This requires some mucking around with files provided directly by Xcode due to some [bugs for adding syntax highlighting in Xcode 11](https://github.com/apollographql/xcode-graphql/issues/23). These issues are addressed as of Xcode 12 beta 2. 
+>
+> This all works as Xcode of 11.5, but be aware that it's a bit more fragile than we'd like it to be. Please file an issue on this repo if it stops working in a new version and we'll investigate. 
+
+The script to run for versions of Xcode other than 11.x is `setup.sh`: 
+
+```
+sudo ./setup-xcode11.sh
+```
+
+Particularly if you are running Catalina, **you will need to use `sudo`** in order to make this work due to changes in the permissions model.
+
+
+## Manual installation
+
+Due to the aforementioned broken APIs, manual installation works slightly differently for Xcode 11 vs. other versions. 
+
+### Anything other than Xcode 11
+
+Please note that the `Plug-ins` and `Specifications` directories might not exist, and if they don't, you'll need to create them.
+
+- Copy the `GraphQL.ideplugin` directory to `~/Library/Developer/Xcode/Plug-ins/`:
+
+	```
+	cp -r GraphQL.ideplugin ~/Library/Developer/Xcode/Plug-ins/
+	```
+- Copy the `GraphQL.xclangspec` file to `~/Library/Developer/Xcode/Specifications`:
+
+	```
+	cp GraphQL.xclangspec ~/Library/Developer/Xcode/Specifications/
+	```
+
+
+### Xcode 11
+
+**Note**: On Catalina you will need to `sudo` to get these commands to work. 
 
 - Copy the `GraphQL.ideplugin` directory to `~/Library/Developer/Xcode/Plug-ins/`:
 
@@ -51,17 +78,3 @@ Due to the aforementioned changes in APIs, manual installation works slightly di
 cp Xcode.SourceCodeLanguage.GraphQL.plist /Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata
 ```
 
-### Versions of Xcode prior to 11
-
-Please note that if you are running Xcode 8 the `Plug-ins` and `Specifications` directories might not exist.
-
-- Copy the `GraphQL.ideplugin` directory to `~/Library/Developer/Xcode/Plug-ins/`:
-
-	```
-	cp -r GraphQL.ideplugin ~/Library/Developer/Xcode/Plug-ins/
-	```
-- Copy the `GraphQL.xclangspec` file to `~/Library/Developer/Xcode/Specifications`:
-
-	```
-	cp GraphQL.xclangspec ~/Library/Developer/Xcode/Specifications/
-	```

--- a/setup-xcode11.sh
+++ b/setup-xcode11.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+
+xcode_contents_dir=$(dirname "$(xcode-select -p)")
+
+# Create plug-ins directory if it doesn't exist
+plugins_dir=~/Library/Developer/Xcode/Plug-ins/
+if [ ! -d "$plugins_dir" ]; then
+	mkdir $plugins_dir
+fi
+
+# Copy the IDE Plugin to the plug-ins directory
+cp -r GraphQL.ideplugin $plugins_dir
+
+# Create Specifications directory if it doesn't exist
+spec_dir="${xcode_contents_dir}/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications"
+if [ ! -d "$spec_dir" ]; then
+	mkdir $spec_dir
+fi
+
+# Copy the language specification to the specs directory
+cp GraphQL.xclangspec $spec_dir
+
+# Create the language metadata directory if it doesn't exist
+metadata_dir="${xcode_contents_dir}/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata"
+if [ ! -d "$metadata_dir" ]; then
+	mkdir $metadata_dir
+fi
+
+# Copy the source code language plist to the metadata directory
+cp Xcode.SourceCodeLanguage.GraphQL.plist $metadata_dir
+
+echo '🎉 Apollo Xcode Add-ons installation has completed! Please restart Xcode and click "Load bundle" when an alert shows about GraphQL.ideplugin.'

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -o xtrace
+# Use this script for versions of Xcode other than Xcode 11.
 
-xcode_contents_dir=$(dirname "$(xcode-select -p)")
+set -o xtrace
 
 # Create plug-ins directory if it doesn't exist
 plugins_dir=~/Library/Developer/Xcode/Plug-ins/
@@ -14,21 +14,9 @@ fi
 cp -r GraphQL.ideplugin $plugins_dir
 
 # Create Specifications directory if it doesn't exist
-spec_dir="${xcode_contents_dir}/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications"
+spec_dir=~/Library/Developer/Xcode/Specifications
 if [ ! -d "$spec_dir" ]; then
 	mkdir $spec_dir
 fi
-
-# Copy the language specification to the specs directory
-cp GraphQL.xclangspec $spec_dir
-
-# Create the language metadata directory if it doesn't exist
-metadata_dir="${xcode_contents_dir}/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata"
-if [ ! -d "$metadata_dir" ]; then
-	mkdir $metadata_dir
-fi
-
-# Copy the source code language plist to the metadata directory
-cp Xcode.SourceCodeLanguage.GraphQL.plist $metadata_dir
 
 echo '🎉 Apollo Xcode Add-ons installation has completed! Please restart Xcode and click "Load bundle" when an alert shows about GraphQL.ideplugin.'


### PR DESCRIPTION
Good news, everyone! Apple finally fixed the nonsense requiring workarounds to get language specs picked up in Xcode 12 beta 2. This means we can go back to not having to do weird things involving `sudo` for versions of Xcode which are not 11. 

I've therefore split out the installation script into two scripts: A more complex one for Xcode 11, and a simple one for everything else, and I've updated installation instructions accordingly. 