### PR TITLE
Add missing copy command

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,9 +14,11 @@ fi
 cp -r GraphQL.ideplugin $plugins_dir
 
 # Create Specifications directory if it doesn't exist
-spec_dir=~/Library/Developer/Xcode/Specifications
+spec_dir=~/Library/Developer/Xcode/Specifications/
 if [ ! -d "$spec_dir" ]; then
 	mkdir $spec_dir
 fi
+
+cp GraphQL.xclangspec $spec_dir
 
 echo '🎉 Apollo Xcode Add-ons installation has completed! Please restart Xcode and click "Load bundle" when an alert shows about GraphQL.ideplugin.'


### PR DESCRIPTION
While looking into an issue that I was having installing the syntax highlighting, I noticed that in `setup.sh` the command to copy `GraphQL.xclangspec` into the `specifications` directory was missing.

This PR adds that line back to the script.