### PR TITLE
Added Xcode 13.0 compatibility

### DIFF
--- a/GraphQL.ideplugin/Contents/Info.plist
+++ b/GraphQL.ideplugin/Contents/Info.plist
@@ -51,6 +51,7 @@
 		<string>3928AC50-EA32-404F-9CAF-49710A35483C</string>
 		<string>2F1A5FFF-BFEB-4498-B2AC-1296A7454F81</string>
 		<string>F56A1938-53DE-493D-9D64-87EE6C415E4D</string>
+		<string>8BAA96B4-5225-471B-B124-D32A349B8106</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
Adding Xcode 13.0 UUID to the compatibility list, following its release.