### PR TITLE
Fix Xcode 12+ indentation and whitespace trimming

### DIFF
--- a/GraphQL.ideplugin/Contents/Resources/GraphQL.xcplugindata
+++ b/GraphQL.ideplugin/Contents/Resources/GraphQL.xcplugindata
@@ -74,6 +74,17 @@
 				<string>Xcode.SourceCodeLanguage</string>
 				<key>version</key>
 				<string>1.0</string>
+				<key>supportsIndentation</key>
+				<true/>
+				<key>allowWhitespaceTrimming</key>
+				<true/>
+				<key>requiresHardTabs</key>
+				<false/>
+				<key>indentationTriggers</key>
+				<array>
+					<string>{</string>
+					<string>}</string>
+				</array>
 			</dict>
 			<key>Xcode.IDEKit.Inspector.FileIdentityAndType.public.graphql-source</key>
 			<dict>


### PR DESCRIPTION
Even though the `supportsIndentation`, `allowWhitespaceTrimming`, `requiresHardTabs` and `indentationTriggers` entries were in the `Xcode.SourceCodeLanguage.GraphQL.plist` file, they were not being copied by `setup.sh` for Xcode 12+  which copies the `.ideplugin` container.

By adding these entries to the `GraphQL.xcplugindata`, they are now copied by `setup.sh` and indentation and whitespace trimming work properly.

Closes #39.

## Changes

- Add following entries to `Xcode.SourceCodeLanguage.GraphQL`'s dictionary in `GraphQL.xcplugindata`:
  + `supportsIndentation`: `true`
  + `allowWhitespaceTrimming`: `true`
  + `requiresHardTabs`: `false`
  + `indentationTriggers`: `[{, }]`


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->