### PR TITLE
Added Xcode 14.3 UUID to Info.plist

### DIFF
--- a/GraphQL.ideplugin/Contents/Info.plist
+++ b/GraphQL.ideplugin/Contents/Info.plist
@@ -58,6 +58,7 @@
 		<string>AF3613FA-81D9-4A8B-8204-9912665677FA</string>
 		<string>B8A1C62D-289E-476A-B0CD-B16ADBDD8395</string>
 		<string>C91F3560-00E7-4749-8E3F-4D83B1496051</string>
+        <string>EA3EACC9-A0BE-423D-9BA3-AA8B9FE68E38</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This add the Xcode 14.3 UUID (EA3EACC9-A0BE-423D-9BA3-AA8B9FE68E38) to Info.plist.